### PR TITLE
Fixed version issue with javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,26 +197,26 @@
         </executions>
       </plugin>
 
-<!--      <plugin>-->
-<!--        <groupId>org.apache.maven.plugins</groupId>-->
-<!--        <artifactId>maven-javadoc-plugin</artifactId>-->
-<!--        <version>2.8.1</version>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>attach-javadocs</id>-->
-<!--            <goals>-->
-<!--              <goal>jar</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--        <configuration>-->
-<!--		  <source>6</source>-->
-<!--          <show>protected</show>-->
-<!--          <nohelp>true</nohelp>-->
-<!--          <additionalparam>-Xdoclint:none</additionalparam>-->
-<!--        </configuration>-->
-<!--      </plugin>-->
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.8.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+		  <source>6</source>
+          <show>protected</show>
+          <nohelp>true</nohelp>
+          <additionalparam>-Xdoclint:none</additionalparam>
+        </configuration>
+      </plugin>
+	  
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,7 @@
 <!--          </execution>-->
 <!--        </executions>-->
 <!--        <configuration>-->
+<!--		  <source>6</source>-->
 <!--          <show>protected</show>-->
 <!--          <nohelp>true</nohelp>-->
 <!--          <additionalparam>-Xdoclint:none</additionalparam>-->


### PR DESCRIPTION
This just adds a source lvl to the configuration of the javadoc plugin. Like for imageviewer I don't see a reason for commenting out the plugin as this only adds a --source option to the javadoc tool. https://docs.oracle.com/javase/1.5.0/docs/tooldocs/windows/javadoc.html#javadocoptions